### PR TITLE
feat: add separate command to open links

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,12 +12,20 @@ return {
 ## Remaps for grabbing git link
 
 ```lua
-vim.keymap.set("n", "<leader>gf", function()
+vim.keymap.set("n", "<leader>gc", function()
   require("sharegitlink").copy_gitfarm_link()
 end, { noremap = true, silent = true })
 
-vim.keymap.set("v", "<leader>gf", function()
+vim.keymap.set("v", "<leader>gc", function()
   require("sharegitlink").copy_gitfarm_link()
+end, { noremap = true, silent = true })
+
+vim.keymap.set("n", "<leader>go", function()
+  require("sharegitlink").open_gitfarm_link()
+end, { noremap = true, silent = true })
+
+vim.keymap.set("v", "<leader>go", function()
+  require("sharegitlink").open_gitfarm_link()
 end, { noremap = true, silent = true })
 ```
 
@@ -29,12 +37,20 @@ return {
   branch = "main",
   keys = {
     {
-      "<leader>gf",
+      "<leader>gc",
       function()
         require("sharegitlink").copy_gitfarm_link()
       end,
       mode = { "n", "v" },
       desc = "Copy Link",
+    },
+    {
+      "<leader>go",
+      function()
+        require("sharegitlink").open_gitfarm_link()
+      end,
+      mode = { "n", "v" },
+      desc = "Open Link",
     },
   },
 }

--- a/lua/sharegitlink/utils.lua
+++ b/lua/sharegitlink/utils.lua
@@ -110,33 +110,17 @@ function M.show_virtual_text(message, line)
 end
 
 function M.open_in_browser(link)
-	local open_link_key = "g"
-	local key_handler
-	key_handler = vim.on_key(function(char)
-		if char == open_link_key then
-			local open_cmd
-			if vim.fn.has("mac") == 1 then
-				open_cmd = { "open", link }
-			elseif vim.fn.has("unix") == 1 then
-				open_cmd = { "xdg-open", link }
-			else
-				vim.notify("Cannot open browser on this OS", vim.log.levels.ERROR)
-				return
-			end
+	local open_cmd
+	if vim.fn.has("mac") == 1 then
+		open_cmd = { "open", link }
+	elseif vim.fn.has("unix") == 1 then
+		open_cmd = { "xdg-open", link }
+	else
+		vim.notify("Cannot open browser on this OS", vim.log.levels.ERROR)
+		return
+	end
 
-			vim.fn.jobstart(open_cmd, { detach = true })
-
-			vim.on_key(nil, key_handler)
-		end
-	end, vim.api.nvim_get_current_buf())
-
-	vim.api.nvim_create_autocmd("CursorMoved", {
-		buffer = 0,
-		once = true,
-		callback = function()
-			vim.on_key(nil, key_handler)
-		end,
-	})
+	vim.fn.jobstart(open_cmd, { detach = true })
 end
 
 return M


### PR DESCRIPTION
Refactor to introduce a separate command for opening links. This approach offers greater flexibility compared to embedding the behavior within the `setup` process.

With this change, users can now access two distinct commands:
- Copy the link
- Open the link
